### PR TITLE
Initialize React TS app with login page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "kpmg-community-admin-portal",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.20.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@types/react-router-dom": "^5.3.3"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>KPMG Community Admin Portal</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/public/kpmg-logo.svg
+++ b/public/kpmg-logo.svg
@@ -1,0 +1,4 @@
+<svg width="100" height="40" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="40" fill="#00338d" />
+  <text x="50" y="25" font-family="Arial" font-size="20" fill="white" text-anchor="middle" dominant-baseline="middle">KPMG</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Login from './pages/Login';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="/login" />} />
+      <Route path="/login" element={<Login />} />
+      {/* Placeholder routes for future pages */}
+      <Route path="/dashboard" element={<div>Dashboard</div>} />
+      <Route path="/settings" element={<div>Settings</div>} />
+    </Routes>
+  );
+}
+
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,13 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -1,0 +1,73 @@
+.login-container {
+  display: flex;
+  height: 100vh;
+}
+
+.login-form {
+  flex: 1;
+  padding: 2rem 4rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  max-width: 480px;
+}
+
+.logo {
+  width: 120px;
+  margin-bottom: 2rem;
+}
+
+.subtitle {
+  color: #666;
+  margin-top: -1rem;
+  margin-bottom: 2rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  margin-bottom: 0.25rem;
+  font-weight: 500;
+}
+
+input {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.login-btn {
+  background-color: #00338d;
+  color: white;
+  padding: 0.75rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-bottom: 0.5rem;
+}
+
+.sso-btn {
+  background-color: white;
+  color: #00338d;
+  padding: 0.75rem;
+  border: 1px solid #00338d;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
+.forgot {
+  font-size: 0.875rem;
+  color: #00338d;
+  text-decoration: none;
+  align-self: flex-end;
+}
+
+.login-image {
+  flex: 1;
+  background: linear-gradient(135deg, #4e46e5, #6bb0f5);
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import './Login.css';
+
+const Login: React.FC = () => {
+  return (
+    <div className="login-container">
+      <div className="login-form">
+        <img src="/kpmg-logo.svg" alt="KPMG" className="logo" />
+        <h2>Welcome to Knitspace</h2>
+        <p className="subtitle">Sign in to your account</p>
+        <form>
+          <label htmlFor="email">Enter your email</label>
+          <input type="email" id="email" placeholder="Enter your email" />
+          <label htmlFor="password">Enter your password</label>
+          <input type="password" id="password" placeholder="Enter your password" />
+          <button type="submit" className="login-btn">Login</button>
+          <button type="button" className="sso-btn">SSO Login</button>
+          <a href="#" className="forgot">Forgot password?</a>
+        </form>
+      </div>
+      <div className="login-image"></div>
+    </div>
+  );
+};
+
+export default Login;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- Scaffold initial React app structure in TypeScript
- Implement KPMG-themed admin login screen with form and styling
- Add basic routing setup for future pages

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04ff978c08320b98b1106ce2d65cd