### PR TITLE
Refine login page styling and add CRA dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "kpmg-community-admin-portal",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.20.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "react-scripts": "^5.0.1",
+    "typescript": "4.9.5"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>KPMG Community Admin Portal</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/public/kpmg-logo.svg
+++ b/public/kpmg-logo.svg
@@ -1,0 +1,4 @@
+<svg width="100" height="40" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="40" fill="#00338d" />
+  <text x="50" y="25" font-family="Arial" font-size="20" fill="white" text-anchor="middle" dominant-baseline="middle">KPMG</text>
+</svg>

--- a/public/login-bg.svg
+++ b/public/login-bg.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4e46e5"/>
+      <stop offset="100%" stop-color="#6bb0f5"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#grad)" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Login from './pages/Login';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="/login" />} />
+      <Route path="/login" element={<Login />} />
+      {/* Placeholder routes for future pages */}
+      <Route path="/dashboard" element={<div>Dashboard</div>} />
+      <Route path="/settings" element={<div>Settings</div>} />
+    </Routes>
+  );
+}
+
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,13 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -1,0 +1,112 @@
+/* Layout */
+.login-container {
+  display: flex;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.login-form {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 4rem 5rem;
+  max-width: 500px;
+  background-color: #fff;
+}
+
+/* Branding */
+.logo {
+  width: 130px;
+  margin-bottom: 2.5rem;
+}
+
+.title {
+  margin: 0 0 0.5rem 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #00338d;
+}
+
+.subtitle {
+  color: #666;
+  margin-bottom: 2.5rem;
+}
+
+/* Form */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+label {
+  font-weight: 500;
+}
+
+input {
+  padding: 0.75rem;
+  border: 1px solid #cfd3d7;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.login-btn {
+  background-color: #00338d;
+  color: #fff;
+  padding: 0.75rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.login-btn:hover {
+  background-color: #00276b;
+}
+
+.sso-btn {
+  background-color: #fff;
+  color: #00338d;
+  padding: 0.75rem;
+  border: 2px solid #00338d;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.sso-btn:hover {
+  background-color: #e6f0ff;
+}
+
+.forgot {
+  font-size: 0.875rem;
+  color: #00338d;
+  text-decoration: none;
+  align-self: flex-end;
+}
+
+.forgot:hover {
+  text-decoration: underline;
+}
+
+/* Image panel */
+.login-image {
+  flex: 1;
+  background: url('/login-bg.svg') center/cover no-repeat;
+}
+
+@media (max-width: 768px) {
+  .login-container {
+    flex-direction: column;
+  }
+
+  .login-image {
+    display: none;
+  }
+
+  .login-form {
+    max-width: none;
+    padding: 2rem;
+  }
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import './Login.css';
+
+const Login: React.FC = () => {
+  return (
+    <div className="login-container">
+      <section className="login-form">
+        <img src="/kpmg-logo.svg" alt="KPMG" className="logo" />
+        <h1 className="title">Welcome to Knitspace</h1>
+        <p className="subtitle">Sign in to your account</p>
+        <form className="form">
+          <label htmlFor="email">Enter your email</label>
+          <input type="email" id="email" placeholder="Enter your email" required />
+          <label htmlFor="password">Enter your password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" className="login-btn">Login</button>
+          <button type="button" className="sso-btn">SSO Login</button>
+          <a href="#" className="forgot">Forgot password?</a>
+        </form>
+      </section>
+      <section className="login-image" aria-hidden="true" />
+    </div>
+  );
+};
+
+export default Login;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add `react-scripts` and pin `typescript` 4.9 to satisfy CRA dependencies
- restyle login page and add gradient graphic to mirror Figma design

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)
- `npm test` (fails: react-scripts: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a04ff978c08320b98b1106ce2d65cd